### PR TITLE
Add Translation Files of Three Chinese Variants

### DIFF
--- a/common/src/main/resources/assets/backupmanager/lang/zh_cn.json
+++ b/common/src/main/resources/assets/backupmanager/lang/zh_cn.json
@@ -1,0 +1,18 @@
+{
+  "backupmanager:gui.backups.title" : "备份列表",
+  "backupmanager:gui.backups.created" : "备份时间: %s",
+  "backupmanager:gui.backups.provider" : "备份来源: %s",
+  "backupmanager:gui.backups.restore_name" : "请输入世界名，选择世界页面将显示该名称",
+  "backupmanager:gui.backups.error_occurred" : "错误！\n\n%s",
+  "backupmanager:gui.backups.restored" : "成功重载备份",
+  "backupmanager:gui.backups.file_location" : "文件位置：",
+
+  "backupmanager:button.backups" : "世界备份",
+  "backupmanager:button.restore_backup" : "还原备份",
+  "backupmanager:button.restore_backup.info" : "输入一个名称以还原此备份。\n将重新创建一个世界，不会覆盖原存档。",
+  "backupmanager:button.delete_backup" : "删除备份",
+  "backupmanager:button.backups_entry" : "管理备份",
+  "backupmanager:button.back_arrow" : "← 返回",
+  "backupmanager:button.ok" : "确定",
+  "backupmanager:button.cancel" : "取消"
+}

--- a/common/src/main/resources/assets/backupmanager/lang/zh_cn.json
+++ b/common/src/main/resources/assets/backupmanager/lang/zh_cn.json
@@ -4,7 +4,7 @@
   "backupmanager:gui.backups.provider" : "备份来源: %s",
   "backupmanager:gui.backups.restore_name" : "请输入世界名，选择世界页面将显示该名称",
   "backupmanager:gui.backups.error_occurred" : "错误！\n\n%s",
-  "backupmanager:gui.backups.restored" : "成功重载备份",
+  "backupmanager:gui.backups.restored" : "成功还原备份",
   "backupmanager:gui.backups.file_location" : "文件位置：",
 
   "backupmanager:button.backups" : "世界备份",

--- a/common/src/main/resources/assets/backupmanager/lang/zh_hk.json
+++ b/common/src/main/resources/assets/backupmanager/lang/zh_hk.json
@@ -1,0 +1,18 @@
+{
+  "backupmanager:gui.backups.title" : "備份列表",
+  "backupmanager:gui.backups.created" : "備份時間：%s",
+  "backupmanager:gui.backups.provider" : "備份來源：%s",
+  "backupmanager:gui.backups.restore_name" : "請輸入世界名稱，選擇世界畫面將顯示該名稱",
+  "backupmanager:gui.backups.error_occurred" : "錯誤！\n\n%s",
+  "backupmanager:gui.backups.restored" : "成功重新載入備份",
+  "backupmanager:gui.backups.file_location" : "文件位置：",
+
+  "backupmanager:button.backups" : "世界備份",
+  "backupmanager:button.restore_backup" : "還原備份",
+  "backupmanager:button.restore_backup.info" : "輸入一個名稱以還原此備份。\n將重新創建一個世界，不會覆蓋原世界存檔。",
+  "backupmanager:button.delete_backup" : "刪除備份",
+  "backupmanager:button.backups_entry" : "管理備份",
+  "backupmanager:button.back_arrow" : "← 返回",
+  "backupmanager:button.ok" : "確認",
+  "backupmanager:button.cancel" : "取消"
+}

--- a/common/src/main/resources/assets/backupmanager/lang/zh_tw.json
+++ b/common/src/main/resources/assets/backupmanager/lang/zh_tw.json
@@ -1,0 +1,18 @@
+{
+  "backupmanager:gui.backups.title" : "備份列表",
+  "backupmanager:gui.backups.created" : "備份時間：%s",
+  "backupmanager:gui.backups.provider" : "備份來源：%s",
+  "backupmanager:gui.backups.restore_name" : "請輸入世界名稱，選擇世界畫面將顯示該名稱",
+  "backupmanager:gui.backups.error_occurred" : "錯誤！\n\n%s",
+  "backupmanager:gui.backups.restored" : "成功重新載入備份",
+  "backupmanager:gui.backups.file_location" : "文件位置：",
+
+  "backupmanager:button.backups" : "世界備份",
+  "backupmanager:button.restore_backup" : "還原備份",
+  "backupmanager:button.restore_backup.info" : "輸入一個名稱以還原此備份。\n將重新創建一個世界，不會覆蓋原世界。",
+  "backupmanager:button.delete_backup" : "刪除備份",
+  "backupmanager:button.backups_entry" : "管理備份",
+  "backupmanager:button.back_arrow" : "← 返回",
+  "backupmanager:button.ok" : "確定",
+  "backupmanager:button.cancel" : "取消"
+}


### PR DESCRIPTION
Add translation files of Chinese of Mainland China, Hong Kong SAR and Taiwan respectively.

`zh_cn`: Simplified Chinese (Mainland China)
`zh_hk`: Traditional Chinese (Hong Kong SAR)
`zh_tw`: Traditional Chinese (Taiwan)